### PR TITLE
Set default APP_BASE_ID for HuBMAP

### DIFF
--- a/src/instance/app.cfg.example
+++ b/src/instance/app.cfg.example
@@ -13,7 +13,7 @@ DB_PASSWORD = '123'
 APP_ID_PREFIX = 'HBM'
 #Set to the ID used in the entity-api
 APP_ID = 'hubmap_id'
-APP_BASE_ID = 'base_id'
+APP_BASE_ID = 'hubmap_base_id'
 
 BASE_DIR_TYPES = ['DATA_UPLOAD', 'INGEST_PORTAL_UPLOAD']
 # Entity types which have a uuids_attributes.BASE_ID associated with them


### PR DESCRIPTION
Set correct value for APP_BASE_ID for HuBMAP in example file (leave unchanged for SenNet.)